### PR TITLE
Fix hono audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "overrides": {
     "@hono/node-server": "^1.19.13",
     "express-rate-limit": "^8.2.2",
-    "hono": "^4.12.12",
+    "hono": "^4.12.14",
     "path-to-regexp": "^8.4.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Raise the `hono` override lower bound from `^4.12.12` to `^4.12.14`
- Refresh `package-lock.json` so the resolved transitive `hono` version is `4.12.14`
- Addresses npm audit advisory GHSA-458j-xx4x-4375 affecting `hono <4.12.14`

## Verification
- `npm audit` -> found 0 vulnerabilities
- `npm run build`
- `npm test` -> 14 files / 76 tests passed
- `npm run check` -> typecheck, tests, build, and smoke test passed